### PR TITLE
Refresh GitHub Pages documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,10 +1,11 @@
 title: LeitnerFlow
-description: Spaced Repetition für Moodle
+description: Professionelle Produkt- und Dokumentationsseite fuer das Moodle-Plugin LeitnerFlow.
 theme: minima
 lang: de
+show_excerpts: false
 
 minima:
-  skin: auto
+  skin: classic
 
 header_pages:
   - teacher-guide.md
@@ -17,3 +18,13 @@ header_pages:
 markdown: kramdown
 kramdown:
   input: GFM
+
+sass:
+  style: compressed
+
+defaults:
+  - scope:
+      path: ""
+      type: pages
+    values:
+      layout: page

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -1,0 +1,94 @@
+---
+layout: page
+title: Guide fuer Administrator:innen
+description: LeitnerFlow installieren, betreiben und sauber in Moodle ausrollen.
+---
+
+<section class="page-hero">
+  <span class="eyebrow">Administration</span>
+  <h1>LeitnerFlow installieren und betrieblich sauber einfuehren</h1>
+  <p class="lead">Dieser Guide richtet sich an Administrator:innen und technische Verantwortliche, die LeitnerFlow in einer Moodle-Umgebung bereitstellen, aktualisieren und nachvollziehbar betreiben wollen. Der Fokus liegt auf einem robusten Rollout ohne zusaetzliche Infrastrukturkomplexitaet.</p>
+</section>
+
+## Technischer Rahmen
+
+LeitnerFlow ist ein Moodle-Modul und orientiert sich eng an den ueblichen Moodle-Mechanismen fuer Installation, Rechte, Frageverarbeitung und Reporting. Das Plugin benoetigt laut Repository eine Umgebung ab Moodle `4.4` und wird in den Modulpfad `mod/eledialeitnerflow` eingebunden.
+
+| Bereich | Empfehlung |
+|---|---|
+| Moodle-Version | ab 4.4, vor Einfuehrung in Testumgebung pruefen |
+| Installationspfad | `mod/eledialeitnerflow` |
+| Einfuehrung | zuerst Staging oder Testsystem, danach produktiv |
+| Verantwortlichkeit | technische Bereitstellung mit enger Abstimmung zur Didaktik |
+
+## Installation
+
+Die Installation folgt dem ueblichen Moodle-Vorgehen fuer Aktivitaetsmodule. Nach dem Einspielen des Quellcodes erkennt Moodle das Plugin beim Aufruf der Mitteilungen und fuehrt die erforderlichen Installationsschritte aus.
+
+1. Laden Sie das Repository in den Pfad `mod/eledialeitnerflow` Ihrer Moodle-Installation.
+2. Rufen Sie in Moodle `Website-Administration -> Mitteilungen` auf.
+3. Lassen Sie das Upgrade durchlaufen und pruefen Sie, ob die Aktivitaet anschliessend in Kursen verfuegbar ist.
+4. Legen Sie eine Testaktivitaet an und kontrollieren Sie den End-to-End-Ablauf aus Admin- oder Trainer-Sicht.
+
+<div class="highlight-box">
+  <p><strong>Empfehlung fuer den Rollout:</strong> Testen Sie die Aktivitaet nicht nur auf Installationsfehler, sondern auch mit einer echten Fragenkategorie und mindestens einer abgeschlossenen Session. Gerade bei Lernaktivitaeten zeigt sich Betriebsqualitaet erst im kompletten Ablauf.</p>
+</div>
+
+## Updates und Versionspflege
+
+Fuer einen professionellen Betrieb sollte die oeffentliche Dokumentation sich immer an der technischen Wahrheit im Repository orientieren. Im vorliegenden Code ist die Release-Angabe in `version.php` massgeblich. Wenn README und Code voneinander abweichen, sollte die Kommunikation nach dem technisch verbindlichen Stand ausgerichtet werden.
+
+Bei Updates empfiehlt sich daher ein kurzer Standardprozess:
+
+<ul class="check-list">
+  <li>Release-Stand in `version.php` pruefen.</li>
+  <li>Upgrade-Hinweise und Changelog gegenlesen.</li>
+  <li>Update zuerst in einer nicht-produktiven Umgebung einspielen.</li>
+  <li>Eine bestehende Aktivitaet mit Lernfortschritt testweise oeffnen.</li>
+  <li>Erst danach in produktive Kurse ausrollen.</li>
+</ul>
+
+## Rechte und Rollen
+
+LeitnerFlow laesst sich gut in bestehende Moodle-Rollenmodelle einordnen. Relevant sind vor allem Berechtigungen fuer das Anlegen der Aktivitaet, das Bearbeiten von Einstellungen, das Bearbeiten von Sessions und das Einsehen von Berichten. Fuer den produktiven Betrieb sollte klar sein, welche Rolle nur Inhalte nutzt und welche Rolle in Fortschritte oder Reset-Funktionen eingreifen darf.
+
+<div class="info-grid">
+  <div class="card">
+    <h3>Kursverantwortliche</h3>
+    <p>Benoetigen typischerweise Rechte zum Anlegen und Verwalten der Aktivitaet sowie zum Einsehen von Berichten.</p>
+  </div>
+  <div class="card">
+    <h3>Lernende</h3>
+    <p>Brauchen Zugriff auf Ansicht und Bearbeitung, aber in der Regel keine administrativen Eingriffe in Konfiguration oder Fortschrittsdaten.</p>
+  </div>
+  <div class="card">
+    <h3>Support und Betrieb</h3>
+    <p>Sollten wissen, welche Rolle fuer Fehleranalyse, Sichtbarkeit und gegebenenfalls Fortschritts-Resets vorgesehen ist.</p>
+  </div>
+</div>
+
+## Was vor dem Rollout geprueft werden sollte
+
+Ein sauberer Rollout ist nicht nur eine technische, sondern auch eine kommunikative Aufgabe. Pruefen Sie daher neben Installation und Rechten auch, ob Lehrende geeignete Fragenkategorien zur Verfuegung haben und ob klar ist, wie LeitnerFlow im Kurs erklaert werden soll.
+
+| Pruefpunkt | Warum er wichtig ist |
+|---|---|
+| Aktivitaet im Kurs waehlbar | Basis fuer jeden weiteren Test |
+| Fragenkategorien vorhanden | Ohne passenden Pool kann keine sinnvolle Session entstehen |
+| Rechte fuer Lehrende korrekt | Sonst scheitert die Einrichtung oft erst im Kurs |
+| Lernendenansicht getestet | Sichtbarkeit und Session-Ablauf frueh pruefen |
+| Bericht und Reset-Funktionen getestet | Relevant fuer Support und Betreuung |
+
+## Datenschutz, Backup und Moodle-Integration
+
+Das Plugin ist nah an den Moodle-Standards entwickelt und bringt laut Repository Unterstuetzung fuer Privacy API, Backup und Restore sowie Event-Logging mit. Das ist fuer den Betrieb wichtig, weil LeitnerFlow damit nicht als isolierte Sonderloesung, sondern als integrierter Teil der Plattform behandelt werden kann.
+
+Im Alltag bedeutet das: Backups sollten LeitnerFlow-Aktivitaeten mitdenken, Testwiederherstellungen sollten Bestandteil groesserer Moodle-Upgradezyklen sein und Support-Teams sollten wissen, dass Session- und Fortschrittsdaten Teil des Betriebsbilds sind.
+
+## Wenn Probleme auftreten
+
+Die haeufigsten Stoerungen sind in der Regel keine Installationsdefekte, sondern Konfigurations-, Rechte- oder Fragepool-Themen. Beginnen Sie die Analyse deshalb mit Sichtbarkeit, Kategorien und Rollen, bevor Sie von einem tieferen Softwarefehler ausgehen. Die passende Schrittfolge finden Sie im [Troubleshooting](troubleshooting.html).
+
+## Empfohlener naechster Schritt
+
+Wenn LeitnerFlow technisch bereitsteht, sollten Lehrende mit dem [Guide fuer Lehrende](teacher-guide.html) weiterarbeiten. So wird aus einer erfolgreichen Installation auch eine didaktisch stimmige Einfuehrung.

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -4,30 +4,26 @@
 @import "minima";
 
 :root {
-  /* eLeDia Core */
   --brand-primary: #194866;
-  --brand-primary-light: #65A1B3;
-  --brand-primary-soft: #A9CBD5;
-  --brand-accent: #F98012;
-  --brand-accent-soft: #FFECDB;
-
-  /* eLeDia neutrals */
+  --brand-primary-light: #65a1b3;
+  --brand-primary-soft: #a9cbd5;
+  --brand-accent: #f98012;
+  --brand-accent-soft: #ffecdb;
   --ink: #000000;
   --text: #353535;
   --muted: #707070;
-  --line: #E9E9E9;
-  --paper: #FFFFFF;
-  --paper-soft: #F3F5F8;
-
-  /* secondary palette */
+  --line: #e9e9e9;
+  --line-strong: #d7dee4;
+  --paper: #ffffff;
+  --paper-soft: #f3f5f8;
   --teal: #267372;
-  --teal-soft: #D1ECEB;
   --green: #669933;
-  --green-soft: #D1E0C1;
-  --magenta: #AB1D79;
-  --magenta-soft: #F5E4EF;
-
-  --shadow: 0 10px 30px rgba(25, 72, 102, 0.08);
+  --magenta: #ab1d79;
+  --shadow-soft: 0 16px 40px rgba(25, 72, 102, 0.08);
+  --shadow-strong: 0 24px 60px rgba(25, 72, 102, 0.14);
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
 }
 
 html {
@@ -35,286 +31,428 @@ html {
 }
 
 body {
-  background: var(--paper-soft);
+  margin: 0;
+  background:
+    radial-gradient(circle at top right, rgba(249, 128, 18, 0.1), transparent 28%),
+    linear-gradient(180deg, #fbfcfd 0%, var(--paper-soft) 55%, #eef3f7 100%);
   color: var(--text);
-  font-family: "DM Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Avenir Next", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   font-size: 17px;
   line-height: 1.75;
 }
 
 .wrapper {
-  max-width: 1120px;
+  max-width: 1160px;
 }
 
 .site-header {
-  border-top: 6px solid var(--brand-accent);
-  border-bottom: 1px solid var(--line);
-  background: rgba(255,255,255,0.92);
-  backdrop-filter: blur(10px);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  border-top: 5px solid var(--brand-accent);
+  border-bottom: 1px solid rgba(25, 72, 102, 0.1);
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(12px);
 }
 
 .site-title,
 .site-title:visited {
   color: var(--brand-primary);
   font-weight: 800;
-  letter-spacing: 0.2px;
+  letter-spacing: -0.01em;
 }
 
 .site-nav .page-link {
+  margin-left: 1.1rem;
   color: var(--text);
   font-weight: 600;
 }
 
-.site-nav .page-link:hover {
+.site-nav .page-link:hover,
+.site-nav .page-link:focus {
   color: var(--brand-accent);
   text-decoration: none;
 }
 
 .page-content {
-  padding-top: 2.5rem;
+  padding: 2rem 0 4rem;
 }
 
-h1, h2, h3, h4 {
+.post-header {
+  display: none;
+}
+
+.post-title,
+.post-content h1,
+.hero h1,
+.page-hero h1 {
   color: var(--brand-primary);
-  line-height: 1.15;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
 }
 
-.post-content h1 {
-  font-size: clamp(2.5rem, 5vw, 4rem);
-  margin-bottom: 1rem;
+.post-title,
+.post-content h1,
+.hero h1 {
+  font-size: clamp(2.9rem, 5vw, 5rem);
+}
+
+.page-hero h1 {
+  font-size: clamp(2.4rem, 4vw, 3.5rem);
+  margin-bottom: 0.75rem;
 }
 
 .post-content h2 {
-  font-size: clamp(1.6rem, 3vw, 2.35rem);
-  margin-top: 3rem;
+  margin-top: 3.25rem;
   margin-bottom: 1rem;
-  padding-bottom: 0.35rem;
-  border-bottom: 1px solid var(--line);
+  color: var(--brand-primary);
+  font-size: clamp(1.65rem, 3vw, 2.3rem);
+  letter-spacing: -0.02em;
 }
 
 .post-content h3 {
+  margin-top: 1.8rem;
+  margin-bottom: 0.65rem;
+  color: var(--brand-primary);
   font-size: 1.25rem;
-  margin-top: 1.6rem;
 }
 
-p {
-  margin-bottom: 1rem;
+.post-content p,
+.post-content li {
+  max-width: 74ch;
+}
+
+p,
+ul,
+ol,
+table,
+blockquote {
+  margin-bottom: 1.2rem;
 }
 
 a {
   color: var(--brand-primary);
+  text-decoration-color: rgba(25, 72, 102, 0.25);
+  text-underline-offset: 0.18em;
 }
 
-a:hover {
+a:hover,
+a:focus {
   color: var(--brand-accent);
 }
 
-.hero {
+.hero,
+.page-hero {
   position: relative;
   overflow: hidden;
-  padding: 3rem 0 1rem;
+  margin-bottom: 2.5rem;
+  padding: 2.6rem;
+  border: 1px solid rgba(25, 72, 102, 0.08);
+  border-radius: 30px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(243, 245, 248, 0.94) 100%);
+  box-shadow: var(--shadow-soft);
 }
 
-.hero::before {
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.9fr);
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.hero::before,
+.page-hero::before {
   content: "";
   position: absolute;
-  top: -150px;
-  right: -120px;
-  width: 480px;
-  height: 480px;
+  inset: auto -90px -120px auto;
+  width: 320px;
+  height: 320px;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(249,128,18,0.22) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(101, 161, 179, 0.22) 0%, transparent 72%);
   pointer-events: none;
 }
 
 .hero::after {
   content: "";
   position: absolute;
-  bottom: -160px;
-  left: -120px;
-  width: 420px;
-  height: 420px;
+  inset: -120px auto auto -100px;
+  width: 280px;
+  height: 280px;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(101,161,179,0.18) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(249, 128, 18, 0.14) 0%, transparent 68%);
   pointer-events: none;
 }
 
+.hero-copy,
+.hero-panel,
+.page-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(160deg, rgba(25, 72, 102, 0.96), rgba(15, 43, 61, 0.96));
+  color: rgba(255, 255, 255, 0.88);
+  box-shadow: var(--shadow-strong);
+}
+
+.hero-panel h2 {
+  margin-top: 0.3rem;
+  margin-bottom: 0.8rem;
+  color: #ffffff;
+  font-size: 1.7rem;
+  line-height: 1.2;
+}
+
+.hero-panel p {
+  margin-bottom: 0;
+}
+
+.panel-label,
 .eyebrow {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: fit-content;
+  margin-bottom: 1rem;
+  padding: 0.35rem 0.9rem;
+  border: 1px solid rgba(249, 128, 18, 0.34);
+  border-radius: 999px;
   background: var(--brand-accent-soft);
   color: var(--brand-accent);
-  border: 1px solid #FCBC82;
-  border-radius: 999px;
-  padding: 0.35rem 0.9rem;
   font-size: 0.82rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  margin-bottom: 1rem;
 }
 
 .lead {
+  max-width: 56rem;
+  color: #4d6270;
   font-size: 1.18rem;
-  color: var(--muted);
-  max-width: 780px;
 }
 
 .button-row {
   display: flex;
-  gap: 0.9rem;
   flex-wrap: wrap;
-  margin-top: 1.6rem;
-  margin-bottom: 2.2rem;
+  gap: 0.85rem;
+  margin-top: 1.7rem;
 }
 
 .button-primary,
 .button-secondary {
-  display: inline-block;
-  padding: 0.85rem 1.4rem;
-  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0.8rem 1.25rem;
+  border-radius: 999px;
   font-weight: 700;
   text-decoration: none !important;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
 }
 
 .button-primary {
-  background: var(--brand-primary);
-  color: #fff !important;
-  box-shadow: var(--shadow);
-}
-
-.button-primary:hover {
-  background: var(--brand-accent);
-  color: #fff !important;
+  background: linear-gradient(135deg, var(--brand-primary) 0%, #153d56 100%);
+  color: #ffffff !important;
+  box-shadow: var(--shadow-soft);
 }
 
 .button-secondary {
-  border: 1.5px solid var(--brand-primary-soft);
+  border: 1px solid rgba(25, 72, 102, 0.16);
+  background: rgba(255, 255, 255, 0.9);
   color: var(--brand-primary) !important;
-  background: rgba(255,255,255,0.75);
 }
 
-.button-secondary:hover {
-  border-color: var(--brand-primary);
+.button-primary:hover,
+.button-secondary:hover,
+.button-primary:focus,
+.button-secondary:focus {
+  transform: translateY(-1px);
 }
 
+.button-primary:hover,
+.button-primary:focus {
+  background: linear-gradient(135deg, #205777 0%, var(--brand-accent) 140%);
+  box-shadow: var(--shadow-strong);
+}
+
+.button-secondary:hover,
+.button-secondary:focus {
+  border-color: rgba(25, 72, 102, 0.34);
+  background: #ffffff;
+}
+
+.metric-band,
 .metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1rem;
-  margin: 2rem 0 2.5rem;
+  margin: 2rem 0 3rem;
 }
 
 .metric {
-  padding: 1rem;
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  background: #fff;
-  box-shadow: var(--shadow);
+  min-height: 100%;
+  padding: 1.25rem;
+  border: 1px solid rgba(25, 72, 102, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shadow-soft);
 }
 
 .metric strong {
   display: block;
-  font-size: 2rem;
-  line-height: 1;
-  margin-bottom: 0.35rem;
+  margin-bottom: 0.45rem;
   color: var(--brand-primary);
+  font-size: 1.8rem;
+  line-height: 1;
+  letter-spacing: -0.03em;
 }
 
 .metric span {
   color: var(--muted);
-  font-size: 0.92rem;
+  font-size: 0.95rem;
 }
 
-.card-grid {
+.card-grid,
+.info-grid,
+.step-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(245px, 1fr));
   gap: 1.2rem;
   margin: 1.5rem 0 2.5rem;
 }
 
-.card {
-  background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  padding: 1.35rem 1.2rem;
-  box-shadow: var(--shadow);
+.card-grid,
+.info-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.card h3 {
+.step-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card,
+.step-card {
+  min-height: 100%;
+  padding: 1.35rem 1.3rem;
+  border: 1px solid rgba(25, 72, 102, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: var(--shadow-soft);
+}
+
+.card h3,
+.step-card h3 {
   margin-top: 0;
-  margin-bottom: 0.45rem;
-  color: var(--brand-primary);
+  margin-bottom: 0.55rem;
 }
 
-.card p {
+.card p,
+.step-card p {
   color: var(--muted);
   margin-bottom: 0.8rem;
 }
 
 .card a {
   font-weight: 700;
-  color: var(--brand-accent);
+  text-decoration: none;
 }
 
-.card a:hover {
-  color: var(--brand-primary);
+.step-card {
+  position: relative;
+  padding-top: 3.4rem;
+}
+
+.step-card > span {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--brand-accent), #f5a14b);
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.highlight-box,
+.soft-panel,
+.cta-strip {
+  margin: 2rem 0;
+  padding: 1.35rem 1.4rem;
+  border-radius: var(--radius-md);
 }
 
 .highlight-box {
-  background: #fff;
-  border: 1px solid #FCBC82;
-  border-left: 4px solid var(--brand-accent);
-  border-radius: 12px;
-  padding: 1rem 1.1rem;
-  margin: 1.2rem 0;
+  border: 1px solid rgba(249, 128, 18, 0.28);
+  border-left: 5px solid var(--brand-accent);
+  background: linear-gradient(135deg, rgba(255, 236, 219, 0.95), rgba(255, 255, 255, 0.98));
 }
 
 .soft-panel {
-  background: linear-gradient(135deg, var(--brand-accent-soft), #fff);
-  border: 1px solid #FCBC82;
-  border-radius: 18px;
-  padding: 1.4rem;
-  margin: 2rem 0;
+  border: 1px solid rgba(101, 161, 179, 0.25);
+  background: linear-gradient(135deg, rgba(169, 203, 213, 0.3), rgba(255, 255, 255, 0.97));
 }
 
 .dark-panel {
-  background: linear-gradient(135deg, var(--brand-primary), #0F2B3D);
-  color: #fff;
-  border-radius: 20px;
-  padding: 1.6rem;
-  margin: 2rem 0;
-  box-shadow: 0 18px 38px rgba(25, 72, 102, 0.16);
+  margin: 2.3rem 0;
+  padding: 1.75rem;
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at top right, rgba(249, 128, 18, 0.18), transparent 25%),
+    linear-gradient(135deg, #194866 0%, #102e42 100%);
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow-strong);
 }
 
 .dark-panel h2,
-.dark-panel h3 {
-  color: #fff;
-  border-bottom: none;
-  margin-top: 0;
-}
-
+.dark-panel h3,
 .dark-panel p,
 .dark-panel li {
-  color: rgba(255,255,255,0.86);
+  color: inherit;
+}
+
+.feature-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.cta-strip {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) auto;
+  gap: 1.2rem;
+  align-items: center;
+  border: 1px solid rgba(25, 72, 102, 0.08);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(243, 245, 248, 0.96));
+  box-shadow: var(--shadow-soft);
 }
 
 .check-list {
-  list-style: none;
   padding-left: 0;
+  list-style: none;
 }
 
 .check-list li {
   position: relative;
   padding-left: 1.8rem;
-  margin-bottom: 0.8rem;
+  margin-bottom: 0.75rem;
 }
 
 .check-list li::before {
-  content: "✓";
+  content: "\\2713";
   position: absolute;
   left: 0;
-  top: 0;
+  top: 0.02rem;
   color: var(--brand-accent);
   font-weight: 800;
 }
@@ -322,46 +460,75 @@ a:hover {
 table {
   width: 100%;
   border-collapse: collapse;
-  margin: 1.2rem 0 1.8rem;
-  background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 12px;
   overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: var(--shadow-soft);
 }
 
-th, td {
-  padding: 0.85rem 1rem;
+th,
+td {
+  padding: 0.95rem 1rem;
   border-bottom: 1px solid var(--line);
   text-align: left;
+  vertical-align: top;
 }
 
 th {
-  background: var(--paper-soft);
+  background: linear-gradient(180deg, rgba(25, 72, 102, 0.06), rgba(25, 72, 102, 0.02));
   color: var(--brand-primary);
+  font-weight: 700;
+}
+
+tr:last-child td {
+  border-bottom: 0;
 }
 
 blockquote {
-  color: var(--text);
+  padding: 1rem 1.2rem;
   border-left: 4px solid var(--brand-accent);
-  background: var(--brand-accent-soft);
-  padding: 0.9rem 1rem;
-  border-radius: 10px;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: rgba(255, 236, 219, 0.88);
+  color: var(--text);
 }
 
-code, pre {
-  border-radius: 10px;
+code,
+pre {
+  border-radius: var(--radius-sm);
 }
 
 pre {
-  background: #0F2B3D;
-  color: #fff;
-  border: 1px solid #194866;
-  padding: 1rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(25, 72, 102, 0.18);
+  background: #102e42;
+  color: #ffffff;
+}
+
+:not(pre) > code {
+  padding: 0.12rem 0.38rem;
+  background: rgba(25, 72, 102, 0.08);
+  color: var(--brand-primary);
 }
 
 .site-footer {
-  border-top: 1px solid var(--line);
-  background: #fff;
+  border-top: 1px solid rgba(25, 72, 102, 0.1);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.footer-col-wrapper,
+.social-links {
+  color: var(--muted);
+}
+
+@media screen and (max-width: 960px) {
+  .hero,
+  .cta-strip,
+  .feature-columns,
+  .metric-band,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media screen and (max-width: 700px) {
@@ -369,7 +536,25 @@ pre {
     font-size: 16px;
   }
 
-  .post-content h1 {
-    font-size: 2.4rem;
+  .site-nav .page-link {
+    margin-left: 0.85rem;
+  }
+
+  .hero,
+  .page-hero {
+    padding: 1.5rem;
+    border-radius: 24px;
+  }
+
+  .post-title,
+  .post-content h1,
+  .hero h1,
+  .page-hero h1 {
+    font-size: clamp(2rem, 10vw, 2.9rem);
+  }
+
+  th,
+  td {
+    padding: 0.8rem 0.85rem;
   }
 }

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -1,0 +1,4 @@
+---
+---
+
+@import "css/style";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,83 @@
+---
+layout: page
+title: Konfiguration
+description: Einstellungen von LeitnerFlow mit didaktischer Einordnung.
+---
+
+<section class="page-hero">
+  <span class="eyebrow">Konfiguration</span>
+  <h1>LeitnerFlow gezielt konfigurieren</h1>
+  <p class="lead">Die Staerke von LeitnerFlow liegt nicht nur im Leitner-Prinzip selbst, sondern in einer Konfiguration, die zum Lernziel passt. Diese Seite beschreibt die wichtigsten Einstellungen und ordnet sie didaktisch ein, damit technische Optionen zu einer stimmigen Lernaktivitaet werden.</p>
+</section>
+
+## Grundprinzip fuer gute Einstellungen
+
+Eine gute Konfiguration schafft Balance: Die Aktivitaet soll klar, motivierend und wiederholungswirksam sein. Zu viele Freiheiten oder ein uebergrosser Fragenpool koennen den Einstieg erschweren. Zu harte Einstellungen koennen motivieren, wenn das Format klar eingefuehrt ist, aber im Erstkontakt auch schnell als streng erlebt werden.
+
+## Wichtige Einstellungen im Ueberblick
+
+| Einstellung | Typische Optionen | Empfehlung fuer den Einstieg | Wirkung auf das Lernverhalten |
+|---|---|---|---|
+| Fragenkategorien | eine oder mehrere Kategorien | klein und thematisch klar starten | bestimmt Relevanz und Qualitaet des Kartenpools |
+| Fragen pro Session | frei waehlbar | 10-20 | steuert, wie alltagstauglich eine Session ist |
+| Anzahl Boxen | 1-5 | 3 | beeinflusst Differenzierung und Erklaerbarkeit |
+| Richtige Antworten bis gelernt | frei waehlbar | moderat starten | bestimmt, wann Inhalte als stabil gelten |
+| Verhalten bei falscher Antwort | Reset, eine Box zurueck, keine Aenderung | Reset oder eine Box zurueck | steuert Strenge und Wiederholungsdruck |
+| Kartenauswahl | untere Boxen priorisieren oder gemischt | untere Boxen priorisieren | fokussiert auf unsichere Inhalte |
+| Fragenrotation | dynamisch oder fester Pool | abhaengig vom Kursziel | beeinflusst Varianz und Vergleichbarkeit |
+| Bewertung | keine oder Prozent gelernter Karten | bewusst entscheiden | macht aus Uebung optional einen benoteten Bestandteil |
+
+## Die wichtigsten Entscheidungen im Detail
+
+### Fragenkategorien
+
+Die Auswahl der Kategorien ist die inhaltlich wichtigste Stellschraube. Ein klar kuratierter Pool sorgt fuer faire, ruhige Sessions. Werden zu viele heterogene Kategorien gemischt, wirkt die Aktivitaet schnell sprunghaft und Lernende verstehen den roten Faden schlechter.
+
+### Session-Groesse
+
+Kurze Sessions erhoehen die Chance, dass LeitnerFlow regelmaessig genutzt wird. Eine zu grosse Session kann inhaltlich zwar reichhaltig sein, senkt aber oft die Alltagstauglichkeit. In vielen Szenarien sind 10 bis 20 Fragen ein guter Bereich.
+
+### Anzahl der Boxen
+
+Drei Boxen bieten einen sehr guten Ausgangspunkt, weil das Prinzip leicht erklaert werden kann. Mehr Boxen erlauben feinere Abstufungen, erhoehen aber den Erklaerungsaufwand. Fuer fortgeschrittene oder langfristige Formate kann das sinnvoll sein.
+
+### Verhalten bei falscher Antwort
+
+Die Fehlerlogik praegt das Erleben der Aktivitaet stark. Ein kompletter Reset macht den Wiederholungsmechanismus sehr deutlich. Eine mildere Rueckstufung kann motivierender wirken, wenn Lernende das Format eher als kontinuierliche Lernbegleitung denn als strenges Training erleben sollen.
+
+### Kartenauswahl
+
+Die Priorisierung niedriger Boxen unterstuetzt das eigentliche Ziel von LeitnerFlow besonders gut: unsichere Inhalte zuerst bearbeiten. Eine gemischte Auswahl kann sinnvoll sein, wenn mehr Varianz oder ein ausgewogeneres Session-Gefuehl gewuenscht ist.
+
+## Bewaehrte Konfigurationsprofile
+
+<div class="card-grid">
+  <div class="card">
+    <h3>Standardprofil fuer den Einstieg</h3>
+    <p>3 Boxen, 10-20 Fragen, Reset auf Box 1, niedrige Boxen zuerst. Dieses Profil ist gut erklaerbar und fuer die meisten Einfuehrungen direkt einsetzbar.</p>
+  </div>
+  <div class="card">
+    <h3>Sanfteres Lernprofil</h3>
+    <p>3-4 Boxen, kleinere Sessions, bei Fehlern nur eine Box zurueck. Gut geeignet, wenn Motivation und niedrige Einstiegshuerden besonders wichtig sind.</p>
+  </div>
+  <div class="card">
+    <h3>Intensives Pruefungstraining</h3>
+    <p>4-5 Boxen, konsequente Fehlerlogik, klar kuratierter Pool. Sinnvoll fuer laengerfristige Wiederholung mit hoher Verbindlichkeit.</p>
+  </div>
+</div>
+
+## Empfehlungen fuer den ersten produktiven Einsatz
+
+<ul class="check-list">
+  <li>Starten Sie mit einer begrenzten Zahl gut passender Fragenkategorien.</li>
+  <li>Waehlen Sie eine Session-Laenge, die realistisch in den Kursalltag passt.</li>
+  <li>Erklaeren Sie die Fehlerlogik vor dem ersten Einsatz explizit.</li>
+  <li>Beobachten Sie nach den ersten Wochen Nutzungshaeufigkeit und Boxenverteilung.</li>
+  <li>Optimieren Sie erst nach realer Nutzung und nicht nur auf Basis theoretischer Annahmen.</li>
+</ul>
+
+## Konfiguration im Zusammenspiel denken
+
+Keine Einstellung wirkt isoliert. Eine grosse Session mit vielen Boxen und strenger Fehlerlogik fuehlt sich anders an als eine kleine Session mit sanfter Rueckstufung. Gute Konfiguration bedeutet deshalb, das Zusammenspiel aus Lernziel, Zielgruppe und Motivation mitzudenken.
+
+Wenn Sie Konfigurationen im Betrieb nachschaerfen, empfiehlt sich eine kurze Kommunikation im Kurs. So bleibt fuer Lernende nachvollziehbar, warum sich das Verhalten der Aktivitaet veraendert hat.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,59 @@
-# FAQ
+---
+layout: page
+title: FAQ
+description: Haeufige Fragen zu LeitnerFlow in Moodle.
+---
 
-Installation prüfen wenn Probleme auftreten.
+<section class="page-hero">
+  <span class="eyebrow">FAQ</span>
+  <h1>Haeufige Fragen zu LeitnerFlow</h1>
+  <p class="lead">Diese Antworten sind bewusst kurz gehalten und greifen typische Rueckfragen aus Einfuehrung, Kursbetrieb und Support auf. Fuer detaillierte Handlungsanweisungen verweisen die Antworten auf die passenden Guides.</p>
+</section>
 
-Kategorien prüfen wenn keine Fragen erscheinen.
+## Was ist der Unterschied zwischen LeitnerFlow und einem normalen Quiz?
 
-Moodle-Version prüfen bei Fehlern.
+Ein klassisches Quiz prueft vor allem einen einzelnen Bearbeitungsmoment. LeitnerFlow organisiert dagegen Wiederholung ueber mehrere Sessions hinweg. Fragen werden zu virtuellen Lernkarten, deren erneutes Auftauchen vom bisherigen Lernerfolg abhaengt. Dadurch entsteht ein kontinuierlicher Lernprozess statt einer einmaligen Messung.
+
+## Fuer welche Inhalte eignet sich LeitnerFlow am besten?
+
+Besonders gut funktioniert das Plugin fuer Inhalte, die regelmaessig abgerufen und gefestigt werden sollen, zum Beispiel Begriffe, Definitionen, Vokabeln, Faktenwissen, Regeln oder standardisierte Entscheidungssituationen. Weniger geeignet sind sehr offene oder stark diskursive Fragestellungen.
+
+## Muessen fuer LeitnerFlow neue Inhalte erstellt werden?
+
+Nein. LeitnerFlow nutzt die Moodle-Fragensammlung. In vielen Faellen kann mit bereits vorhandenen Kategorien gearbeitet werden. Oft reicht es, den vorhandenen Pool etwas zu kuratieren, damit Anspruchsniveau und Fragequalitaet besser zum wiederholungsorientierten Einsatz passen.
+
+## Warum erscheinen manche Fragen oefter als andere?
+
+Das ist der Kern des Leitner-Prinzips. Karten in unteren Boxen gelten als unsicher und werden deshalb frueher wiederholt. Karten in hoeheren Boxen erscheinen seltener, weil ihr Inhalt bereits stabiler sitzt. Genau diese Gewichtung macht LeitnerFlow didaktisch wirksam.
+
+## Ist ein Rueckschritt nach einer falschen Antwort ein Problem?
+
+Nein. Ein Rueckschritt ist kein technischer Fehler und auch keine Bestrafung, sondern ein Signal im Wiederholungsprozess. Lernende sehen dadurch, welche Inhalte noch nicht stabil genug sind. Wichtig ist, diese Logik bei der Einfuehrung klar zu kommunizieren.
+
+## Kann LeitnerFlow benotet werden?
+
+Ja, das Plugin unterstuetzt eine optionale Bewertungsintegration. Ob das sinnvoll ist, haengt vom Einsatzszenario ab. In vielen Faellen ist LeitnerFlow als formative Lernaktivitaet besonders stark. Wenn Sie eine Bewertung aktivieren, sollte die Logik fuer Lernende transparent erklaert werden.
+
+## Welche Moodle-Version wird unterstuetzt?
+
+Im Repository ist Moodle `4.4+` als technische Voraussetzung hinterlegt. Fuer oeffentliche Kommunikation empfiehlt es sich, diese Angabe regelmaessig mit der jeweils aktuellen Plugin-Version im Code abzugleichen.
+
+## Was tun, wenn keine Fragen angezeigt werden?
+
+Pruefen Sie zuerst, ob der Aktivitaet gueltige Fragenkategorien zugewiesen wurden und ob der zugrunde liegende Pool ueberhaupt passende Fragen enthaelt. Danach lohnt ein Blick auf Rechte, Sichtbarkeit und die konkrete Aktivitaetskonfiguration. Eine strukturierte Pruefreihenfolge finden Sie im [Troubleshooting](troubleshooting.html).
+
+## Wie gross sollte eine Session sein?
+
+Fuer die meisten Kurse sind `10 bis 20` Fragen pro Session ein guter Start. Die Aktivitaet bleibt damit kurz genug fuer den Alltag und lang genug, um einen merkbaren Wiederholungseffekt zu erzeugen. Bei sehr komplexen Fragen kann auch eine kleinere Session-Groesse sinnvoll sein.
+
+## Sind mehr Boxen automatisch besser?
+
+Nicht unbedingt. Mehr Boxen erlauben feinere Abstufungen, machen das System aber auch etwas erklaerungsbeduerftiger. Fuer viele Einfuehrungen sind `3` Boxen ein sehr guter Ausgangspunkt. Erst wenn das Prinzip etabliert ist, lohnt sich gegebenenfalls eine staerkere Differenzierung.
+
+## Sollte bei falschen Antworten immer auf Box 1 zurueckgesetzt werden?
+
+Der komplette Reset macht das Prinzip besonders klar und betont den Wiederholungscharakter. In sensibleren Szenarien kann eine mildere Rueckstufung sinnvoll sein, etwa "eine Box zurueck". Die passende Wahl haengt davon ab, wie motivierend oder streng das Lernformat erlebt werden soll.
+
+## Wie fuehre ich LeitnerFlow gut im Kurs ein?
+
+Am besten mit einer kurzen didaktischen Einordnung: Warum gibt es das Format, wie oft sollen Sessions stattfinden und warum tauchen unsichere Karten haeufiger auf? Wenn Lernende diese drei Punkte verstehen, steigt die Akzeptanz erfahrungsgemaess deutlich. Der [Guide fuer Lehrende](teacher-guide.html) hilft bei der Kommunikation im Kurs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,26 +1,16 @@
+---
+layout: page
+title: Erste Schritte
+description: Einstiegspunkte fuer LeitnerFlow.
+nav_exclude: true
+---
+
 # Erste Schritte
 
-## Aktivität anlegen
+Diese Seite bleibt als kompakter Einstiegspunkt erhalten, damit bestehende Links nicht ins Leere laufen. Fuer die aktuelle Dokumentation sind heute vor allem drei Bereiche relevant:
 
-1. Öffne einen Kurs in Moodle
-2. Klicke auf "Aktivität oder Material anlegen"
-3. Wähle "LeitnerFlow"
+- [Startseite](index.html) fuer Produktueberblick und Einsatzszenarien
+- [Guide fuer Lehrende](teacher-guide.html) fuer didaktische Planung und Kurseinsatz
+- [Guide fuer Administrator:innen](admin-guide.html) fuer Installation, Betrieb und Rollout
 
-## Konfiguration
-
-- Wähle eine oder mehrere Fragenkategorien
-- Lege die Anzahl der Fragen pro Sitzung fest
-- Bestimme die Anzahl der Boxen
-- Definiere das Verhalten bei falschen Antworten
-
-## Aktivität speichern
-
-Nach dem Speichern ist die Aktivität für Lernende verfügbar.
-
-## Lernendenansicht
-
-Lernende sehen:
-
-- ihre aktuellen Boxen
-- Fortschritt
-- Startbutton für eine neue Sitzung
+Wenn Sie LeitnerFlow als lernwirksame Aktivitaet einfuehren moechten, beginnen Sie am besten mit der Startseite und wechseln dann in den fuer Ihre Rolle passenden Guide.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,157 +1,227 @@
 ---
 layout: page
 title: LeitnerFlow
+permalink: /
+description: Produkt- und Dokumentationsseite fuer das Moodle-Plugin LeitnerFlow.
 ---
 
-<div class="hero">
+<section class="hero hero-home">
+  <div class="hero-copy">
+    <span class="eyebrow">eLeDia | Moodle-Plugin | Adaptives Wiederholen</span>
+    <h1>LeitnerFlow bringt intelligentes Wiederholen direkt in Moodle.</h1>
+    <p class="lead">
+      LeitnerFlow verwandelt Fragen aus der Moodle-Fragensammlung in virtuelle Lernkarten, die sich nach dem Leitner-Prinzip durch mehrere Boxen bewegen. Unsichere Inhalte tauchen frueher wieder auf, sichere Inhalte spaeter. So entsteht aus vorhandenen Fragen ein ruhiger, nachhaltiger Lernprozess statt einer einmaligen Abfrage.
+    </p>
+    <div class="button-row">
+      <a class="button-primary" href="teacher-guide.html">Didaktisch einsetzen</a>
+      <a class="button-secondary" href="admin-guide.html">Installation und Betrieb</a>
+    </div>
+  </div>
+  <div class="hero-panel">
+    <p class="panel-label">Produktversprechen</p>
+    <h2>Lernfortschritt wird sichtbar, Wiederholung planbar und die Moodle-Fragensammlung didaktisch wertvoller.</h2>
+    <p>
+      LeitnerFlow eignet sich fuer Kurse, in denen Faktenwissen, Begriffe, Regeln oder prufungsrelevante Inhalte nicht nur praesentiert, sondern verlaesslich gefestigt werden sollen.
+    </p>
+  </div>
+</section>
 
-<span class="eyebrow">eLeDia · Moodle Plugin · Adaptives Lernen</span>
-
-# LeitnerFlow — intelligentes Lernen mit dem Leitner-System
-
-<p class="lead">
-LeitnerFlow verbindet die Moodle-Fragensammlung mit einem strukturierten Wiederholungsprinzip. Aus einzelnen Fragen werden virtuelle Lernkarten, die sich abhängig vom Lernerfolg durch mehrere Boxen bewegen. Schwierige Inhalte erscheinen häufiger, bereits sichere Inhalte seltener. So entsteht ein Lernprozess, der nicht nur prüft, sondern Wissen systematisch festigt.
-</p>
-
-<div class="button-row">
-  <a class="button-primary" href="teacher-guide.md">LeitnerFlow didaktisch einsetzen</a>
-  <a class="button-secondary" href="admin-guide.md">Installation & Betrieb</a>
-</div>
-
-</div>
-
-<div class="metrics">
+<section class="metric-band">
   <div class="metric">
-    <strong>1–5</strong>
-    <span>konfigurierbare Leitner-Boxen</span>
+    <strong>1-5</strong>
+    <span>konfigurierbare Leitner-Boxen fuer unterschiedliche Anspruchsniveaus</span>
+  </div>
+  <div class="metric">
+    <strong>Moodle 4.4+</strong>
+    <span>nahtlose Einbindung in aktuelle Moodle-Umgebungen</span>
+  </div>
+  <div class="metric">
+    <strong>Question Bank</strong>
+    <span>direkte Nutzung bestehender Fragenkategorien statt doppelter Inhaltspflege</span>
   </div>
   <div class="metric">
     <strong>DE / EN</strong>
-    <span>mehrsprachig einsetzbar</span>
+    <span>mehrsprachig einsetzbar fuer Lehrende, Admins und Lernende</span>
   </div>
-  <div class="metric">
-    <strong>Moodle</strong>
-    <span>direkte Nutzung der Fragensammlung</span>
-  </div>
-  <div class="metric">
-    <strong>Flexibel</strong>
-    <span>für Schule, Hochschule und Training</span>
-  </div>
-</div>
+</section>
 
 ## Warum LeitnerFlow?
 
-Digitale Lernangebote scheitern oft nicht an fehlenden Inhalten, sondern an fehlender Wiederholung. Genau hier setzt LeitnerFlow an. Statt Lernende durch große Fragesammlungen ohne Struktur zu schicken, schafft das Plugin einen klaren Rhythmus: Inhalte mit Unsicherheit werden priorisiert, sichere Inhalte treten in den Hintergrund.
+Viele digitale Lernangebote liefern gute Inhalte, aber keinen belastbaren Wiederholungsrhythmus. LeitnerFlow schliesst genau diese Luecke. Das Plugin verbindet die vertraute Moodle-Fragensammlung mit einem adaptiven Lernprinzip, das Lernende systematisch durch sichere und unsichere Inhalte fuehrt. Wiederholung wird damit nicht dem Zufall ueberlassen, sondern Teil eines nachvollziehbaren Lernwegs.
 
-<div class="highlight-box">
-<p><strong>Der Kernnutzen:</strong> LeitnerFlow macht aus Moodle-Fragen kein statisches Quiz, sondern ein wiederholungsorientiertes Lernsystem mit sichtbarem Fortschritt und klarer didaktischer Logik.</p>
+<div class="info-grid">
+  <div class="card">
+    <h3>Didaktisch klar</h3>
+    <p>Das Leitner-System ist leicht zu erklaeren und im Lernalltag sofort nachvollziehbar. Richtig beantwortete Karten steigen auf, schwierige Karten bleiben praesent.</p>
+  </div>
+  <div class="card">
+    <h3>Organisatorisch effizient</h3>
+    <p>Lehrende arbeiten mit vorhandenen Fragenkategorien weiter. Es entsteht kein paralleles Kartensystem ausserhalb von Moodle.</p>
+  </div>
+  <div class="card">
+    <h3>Motivierend fuer Lernende</h3>
+    <p>Fortschritt ist sichtbar, Sessions bleiben ueberschaubar und Lernende erleben den Unterschied zwischen Wiederholen und bloss erneut testen.</p>
+  </div>
 </div>
 
-## Für wen ist LeitnerFlow gedacht?
+<div class="highlight-box">
+  <p><strong>Im Kern ist LeitnerFlow kein Quiz mit anderer Optik.</strong> Es ist eine Lernaktivitaet fuer wiederholungsorientiertes Ueben, bei der die Fragefrequenz aus dem bisherigen Lernerfolg entsteht.</p>
+</div>
+
+## Fuer welche Zielgruppen ist die Seite gedacht?
+
+Die Dokumentation ist bewusst nicht nur technisch aufgebaut. Sie soll sowohl den Produktcharakter von LeitnerFlow vermitteln als auch die konkrete Einfuehrung im Moodle-Alltag unterstuetzen.
 
 <div class="card-grid">
   <div class="card">
-    <h3>👩‍🏫 Für Lehrende</h3>
-    <p>LeitnerFlow hilft dabei, Wiederholung als festen Bestandteil des Kursdesigns zu etablieren. Statt nur Wissen bereitzustellen, entsteht ein Prozess, der regelmäßiges Üben unterstützt und sichtbar macht.</p>
-    <a href="teacher-guide.md">Guide für Lehrende →</a>
+    <h3>Lehrende</h3>
+    <p>Finden Hinweise fuer Kursdesign, geeignete Fragentypen, sinnvolle Konfigurationen und die Begleitung von Lernenden im laufenden Semester.</p>
+    <a href="teacher-guide.html">Zum Guide fuer Lehrende</a>
   </div>
   <div class="card">
-    <h3>🛠️ Für Administrator:innen</h3>
-    <p>Die Aktivität lässt sich in Moodle sauber integrieren und in bestehende Kursstrukturen einbetten. Für den Betrieb sind vor allem Version, Plugin-Pfad und Konfiguration relevant.</p>
-    <a href="admin-guide.md">Administrationsdoku →</a>
+    <h3>Administrator:innen</h3>
+    <p>Erhalten eine kompakte Uebersicht zu Installation, Versionen, Betriebsfragen, Rollout und typischen Pruefpunkten fuer eine stabile Einfuehrung.</p>
+    <a href="admin-guide.html">Zur Admin-Dokumentation</a>
   </div>
   <div class="card">
-    <h3>🎓 Für Lernende</h3>
-    <p>Lernende arbeiten in fokussierten Sessions, erhalten direktes Feedback und sehen unmittelbar, welche Inhalte bereits gefestigt sind und wo weitere Wiederholung sinnvoll ist.</p>
-    <a href="student-guide.md">Lernendenansicht →</a>
+    <h3>Lernende</h3>
+    <p>Verstehen, wie Sitzungen ablaufen, warum Karten unterschiedlich oft erscheinen und wie sich ein regelmaessiger Lernrhythmus sinnvoll aufbauen laesst.</p>
+    <a href="student-guide.html">Zur Lernendenansicht</a>
   </div>
 </div>
 
-## Das Prinzip hinter dem Plugin
+## So funktioniert das Leitner-Prinzip in LeitnerFlow
 
-LeitnerFlow basiert auf einem einfachen, sehr wirkungsvollen Ablauf:
+LeitnerFlow nutzt die Moodle Question Engine, setzt den Schwerpunkt aber auf Wiederholung statt auf Pruefungslogik. Aus einer oder mehreren Fragenkategorien wird ein Kartenpool erzeugt. Jede Frage startet in einer unteren Box. Erfolgreiche Antworten bewegen die Karte weiter nach oben. Fehlerhafte Antworten fuehren - je nach Konfiguration - zu einem Rueckschritt oder zu einem Reset.
 
-1. Eine Lehrkraft wählt Fragenkategorien aus der Moodle-Fragensammlung.
-2. Jede Frage wird als Lernkarte behandelt.
-3. Eine richtige Antwort bewegt die Karte in eine höhere Box.
-4. Eine falsche Antwort setzt die Karte je nach Konfiguration zurück oder stuft sie herab.
-5. Karten aus unteren Boxen erscheinen häufiger erneut.
-6. Nach ausreichend vielen richtigen Antworten gilt eine Karte als gelernt.
+<div class="step-grid">
+  <div class="step-card">
+    <span>1</span>
+    <h3>Fragen auswaehlen</h3>
+    <p>Eine Lehrkraft bindet passende Kategorien aus der Moodle-Fragensammlung in eine Aktivitaet ein.</p>
+  </div>
+  <div class="step-card">
+    <span>2</span>
+    <h3>Karten erzeugen</h3>
+    <p>Jede Frage wird als virtuelle Lernkarte behandelt und in den Wiederholungsprozess aufgenommen.</p>
+  </div>
+  <div class="step-card">
+    <span>3</span>
+    <h3>In Sessions ueben</h3>
+    <p>Lernende bearbeiten kurze, fokussierte Durchgaenge mit einer konfigurierbaren Zahl an Fragen.</p>
+  </div>
+  <div class="step-card">
+    <span>4</span>
+    <h3>Fortschritt steuern</h3>
+    <p>Richtige Antworten verschieben Karten nach oben, unsichere Inhalte tauchen schneller wieder auf.</p>
+  </div>
+  <div class="step-card">
+    <span>5</span>
+    <h3>Lernstand sichtbar machen</h3>
+    <p>Dashboard, Boxenverteilung und Verlauf zeigen, welche Inhalte bereits gefestigt sind und wo weiterer Bedarf besteht.</p>
+  </div>
+  <div class="step-card">
+    <span>6</span>
+    <h3>Langfristig sichern</h3>
+    <p>Die Wiederholung folgt einer klaren Logik und unterstuetzt gerade bei prufungsrelevanten Inhalten den nachhaltigen Wissensaufbau.</p>
+  </div>
+</div>
 
 <div class="soft-panel">
-<p><strong>Didaktischer Effekt:</strong> Wiederholung wird nicht dem Zufall überlassen. Lernende investieren ihre Zeit stärker in unsichere Inhalte und erleben Fortschritt nicht nur als Punktzahl, sondern als Weg durch einen nachvollziehbaren Lernprozess.</p>
+  <p><strong>Didaktischer Mehrwert:</strong> Lernzeit wird dort investiert, wo sie den groessten Effekt hat. Schwierige Inhalte bleiben im Fokus, waehrend bereits sichere Karten seltener erscheinen. Das reduziert Redundanz und macht Ueben effizienter.</p>
 </div>
 
 ## Typische Einsatzszenarien
 
-LeitnerFlow eignet sich überall dort, wo Wissen schrittweise aufgebaut und langfristig gesichert werden soll.
+LeitnerFlow spielt seine Staerken ueberall dort aus, wo regelmaessiges Wiederholen wichtiger ist als ein einmaliger Testmoment. Besonders wirksam ist das Plugin in Formaten mit vielen Begriffen, Fakten, Zuordnungen oder standardisierten Entscheidungsregeln.
 
-<ul class="check-list">
-  <li>Prüfungsvorbereitung über mehrere Wochen hinweg</li>
-  <li>Vokabel- und Begriffstraining</li>
-  <li>Faktenwissen in naturwissenschaftlichen oder medizinischen Kontexten</li>
-  <li>Begleitende Wiederholung in Blended-Learning-Szenarien</li>
-  <li>Microlearning und kurze, regelmäßige Selbstlernphasen</li>
-</ul>
-
-## Was macht LeitnerFlow im Alltag stark?
-
-Im praktischen Einsatz überzeugt LeitnerFlow vor allem durch die Verbindung von didaktischer Klarheit und technischer Einfachheit. Lehrende müssen keine zweite Inhaltswelt pflegen, weil direkt mit der vorhandenen Moodle-Fragensammlung gearbeitet wird. Lernende wiederum erhalten ein Format, das übersichtlich bleibt und dennoch einen echten Wiederholungseffekt erzeugt.
-
-<div class="dark-panel">
-
-## Funktionsschwerpunkte
-
-### Für Lernende
-- sichtbarer Lernfortschritt
-- kurze und fokussierte Sessions
-- Priorisierung unsicherer Inhalte
-- klare Orientierung bis zum Status „gelernt“
-
-### Für Lehrende
-- flexible Auswahl mehrerer Fragenkategorien
-- konfigurierbare Session-Größe und Boxenzahl
-- unterschiedliche Strategien bei falschen Antworten
-- auswertbare Berichte zum Lernstand
-
-### Für Organisation und Betrieb
-- Nutzung der Moodle Question Engine
-- direkte Einbindung in bestehende Kurse
-- saubere Struktur für technische Einführung und Dokumentation
-- professionelle Darstellung für Produkt- und Kundenseiten
-
+<div class="card-grid">
+  <div class="card">
+    <h3>Pruefungsvorbereitung</h3>
+    <p>Begleitendes Wiederholen ueber mehrere Wochen statt kurzfristigem Pauk-Modus kurz vor dem Termin.</p>
+  </div>
+  <div class="card">
+    <h3>Blended Learning</h3>
+    <p>Praesenz- und Selbstlernphasen lassen sich mit kurzen LeitnerFlow-Sessions eng miteinander verzahnen.</p>
+  </div>
+  <div class="card">
+    <h3>Vokabeln und Begriffe</h3>
+    <p>Ideal fuer Sprachlernen, Fachterminologie oder Definitionen, die wiederholt verfuegbar sein muessen.</p>
+  </div>
+  <div class="card">
+    <h3>Berufliche Qualifizierung</h3>
+    <p>Gut geeignet fuer Schulungen, Zertifizierungsvorbereitung und standardisierte Wissensbausteine im Training.</p>
+  </div>
 </div>
 
-## Weiterführende Dokumentation
+## Was LeitnerFlow im Alltag stark macht
+
+Im produktiven Einsatz ueberzeugt LeitnerFlow durch eine unaufgeregte Kombination aus didaktischer Stringenz und technischer Naehe zu Moodle. Lehrende muessen keine neue Inhaltswelt aufbauen, Admins bleiben in einer vertrauten Betriebsumgebung und Lernende erhalten ein Format, das klein genug fuer den Alltag und dennoch wirksam genug fuer langfristiges Lernen ist.
+
+<div class="dark-panel">
+  <h2>Starke Eigenschaften auf einen Blick</h2>
+  <div class="feature-columns">
+    <div>
+      <h3>Fuer Lernende</h3>
+      <ul class="check-list">
+        <li>sichtbarer Fortschritt auf Karten- und Session-Ebene</li>
+        <li>kurze, fokussierte Uebungseinheiten</li>
+        <li>klare Priorisierung unsicherer Inhalte</li>
+        <li>mehrsprachige Nutzung im Moodle-Kontext</li>
+      </ul>
+    </div>
+    <div>
+      <h3>Fuer Lehrende und Organisation</h3>
+      <ul class="check-list">
+        <li>direkte Nutzung der Moodle-Fragensammlung</li>
+        <li>konfigurierbare Session-Groesse, Boxenzahl und Fehlerlogik</li>
+        <li>Berichte und Fortschrittsansichten fuer die Begleitung</li>
+        <li>kompatibel mit GitHub Pages als oeffentliche Produktdokumentation</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+## Orientierung fuer den Einstieg
+
+Fuer viele Moodle-Kurse ist eine bewusst einfache Startkonfiguration sinnvoll. Ein klarer, ueberschaubarer Einstieg erleichtert die Kommunikation gegenueber Lernenden und macht den Nutzen des Leitner-Prinzips schnell erfahrbar.
+
+| Einstellung | Empfehlung fuer den Start | Warum das sinnvoll ist |
+|---|---|---|
+| Anzahl Boxen | 3 | Gut verstaendlich und ohne unnoetige Komplexitaet erklaerbar |
+| Fragen pro Session | 10-20 | Kurz genug fuer den Alltag, lang genug fuer einen sichtbaren Effekt |
+| Verhalten bei Fehlern | Reset auf Box 1 | Macht das Prinzip klar und betont Wiederholung unsicherer Inhalte |
+| Auswahlstrategie | Niedrige Boxen priorisieren | Unterstuetzt fokussiertes Ueben statt breiter Streuung |
+| Einsatzform | Mehrere kurze Sessions pro Woche | Foerdert nachhaltiges Lernen besser als seltene Langsessions |
+
+## Weiterfuehrende Bereiche
 
 <div class="card-grid">
   <div class="card">
     <h3>Konfiguration</h3>
-    <p>Alle Einstellungen der Aktivität im Überblick – mit Empfehlungen für einen klaren und didaktisch sinnvollen Einstieg.</p>
-    <a href="configuration.md">Konfiguration lesen →</a>
+    <p>Alle relevanten Einstellungen mit didaktischer Einordnung, empfohlenen Profilen und Hinweisen fuer einen stabilen Start.</p>
+    <a href="configuration.html">Konfiguration ansehen</a>
   </div>
   <div class="card">
     <h3>Troubleshooting</h3>
-    <p>Wenn Fragen nicht erscheinen, die Aktivität nicht sichtbar ist oder der Fortschritt unplausibel wirkt, findest du hier die typischen Ursachen.</p>
-    <a href="troubleshooting.md">Probleme lösen →</a>
+    <p>Typische Fehlerbilder, schnelle Pruefschritte und Hinweise fuer Support, Betrieb und Einfuehrung.</p>
+    <a href="troubleshooting.html">Probleme systematisch loesen</a>
   </div>
   <div class="card">
     <h3>FAQ</h3>
-    <p>Kurze Antworten auf häufige Fragen zu Nutzung, Didaktik, Fragenpools und typischen Szenarien in Moodle-Kursen.</p>
-    <a href="faq.md">Zur FAQ →</a>
+    <p>Kurze Antworten auf wiederkehrende Fragen zu Didaktik, Betrieb, Fragepools, Bewertung und Lernpraxis.</p>
+    <a href="faq.html">Zur FAQ</a>
   </div>
 </div>
 
-## Empfehlung für den Einstieg
-
-Für die meisten Kurse ist ein einfacher Start sinnvoll. Ein überschaubarer Rahmen hilft sowohl Lehrenden als auch Lernenden, das Prinzip schnell zu verstehen und im Alltag konsequent zu nutzen.
-
-| Einstellung | Empfehlung |
-|---|---|
-| Anzahl Boxen | 3 |
-| Fragen pro Session | 10–20 |
-| Verhalten bei Fehlern | Reset auf Box 1 |
-| Auswahlstrategie | Niedrige Boxen priorisieren |
-| Einsatzform | kurze, regelmäßige Sessions |
-
-Mit dieser Konfiguration entsteht ein klarer, verständlicher Einstieg, der die Stärke des Leitner-Prinzips sichtbar macht, ohne unnötig komplex zu wirken.
+<section class="cta-strip">
+  <div>
+    <p class="panel-label">Naechster Schritt</p>
+    <h2>Mit der passenden Perspektive einsteigen</h2>
+    <p>Wenn Sie LeitnerFlow einrichten, starten Sie mit dem Admin-Guide. Wenn Sie die Aktivitaet in einem Kurs einsetzen moechten, ist der Guide fuer Lehrende der beste Einstieg.</p>
+  </div>
+  <div class="button-row">
+    <a class="button-primary" href="teacher-guide.html">Guide fuer Lehrende</a>
+    <a class="button-secondary" href="admin-guide.html">Guide fuer Admins</a>
+  </div>
+</section>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,27 +1,16 @@
+---
+layout: page
+title: Installation
+description: Verweis auf die aktuelle Installationsdokumentation.
+nav_exclude: true
+---
+
 # Installation
 
-## Voraussetzungen
+Die Installations- und Betriebsinformationen wurden in den [Guide fuer Administrator:innen](admin-guide.html) ueberfuehrt, damit technische Einfuehrung, Upgrade-Hinweise und Rollout-Empfehlungen an einer Stelle gebuendelt bleiben.
 
-- Moodle 4.4 oder höher
-- Zugriff auf das Dateisystem der Moodle-Installation
+Wenn Sie LeitnerFlow neu in Moodle bereitstellen, nutzen Sie bitte diese Reihenfolge:
 
-## Installation aus GitHub
-
-Repository klonen und in den Moodle-Ordner mod kopieren.
-
-Zielpfad:
-/moodle/mod/eledialeitnerflow
-
-## Installation abschließen
-
-1. Öffne Moodle im Browser
-2. Gehe zu: Website-Administration → Mitteilungen
-3. Moodle erkennt das neue Plugin und führt die Installation durch
-
-## Überprüfung
-
-- Kurs erstellen
-- Aktivität hinzufügen
-- LeitnerFlow auswählen
-
-Wenn sichtbar, ist die Installation erfolgreich.
+1. [Guide fuer Administrator:innen](admin-guide.html)
+2. [Konfiguration](configuration.html)
+3. [Troubleshooting](troubleshooting.html) fuer den Fall, dass nach dem Rollout Fragen offen bleiben

--- a/docs/student-guide.md
+++ b/docs/student-guide.md
@@ -1,0 +1,77 @@
+---
+layout: page
+title: Guide fuer Lernende
+description: LeitnerFlow aus Sicht der Lernenden verstehen und sinnvoll nutzen.
+---
+
+<section class="page-hero">
+  <span class="eyebrow">Lernende</span>
+  <h1>Mit LeitnerFlow fokussiert und nachhaltig lernen</h1>
+  <p class="lead">LeitnerFlow hilft dabei, Wissen nicht nur einmal abzurufen, sondern Schritt fuer Schritt zu festigen. Dieser Guide erklaert, was in einer Session passiert, warum manche Fragen oefter wiederkommen und wie Sie das Format fuer Ihren Lernalltag sinnvoll nutzen.</p>
+</section>
+
+## Was LeitnerFlow fuer Sie tut
+
+LeitnerFlow ist kein normales Quiz. Die Aktivitaet ist darauf ausgelegt, Inhalte mehrfach in passenden Abstaenden zu wiederholen. Fragen, die noch unsicher sind, erscheinen frueher erneut. Fragen, die Sie bereits sicher beantworten, treten in den Hintergrund. Genau dadurch konzentriert sich Ihre Lernzeit auf das, was fuer den Fortschritt gerade am wichtigsten ist.
+
+## So laeuft eine Session ab
+
+1. Sie oeffnen die Aktivitaet in Ihrem Moodle-Kurs.
+2. LeitnerFlow stellt eine ueberschaubare Anzahl an Fragen fuer die aktuelle Session zusammen.
+3. Nach jeder Antwort verarbeitet das System, ob die zugehoerige Karte weiter aufsteigt oder erneut geuebt werden sollte.
+4. Nach Abschluss sehen Sie Ihren Fortschritt und koennen die naechste Session spaeter anschliessen.
+
+Kurze Sessions sind dabei ausdruecklich gewollt. Sie muessen nicht alles in einem Durchgang schaffen. Oft ist es wirksamer, mehrmals pro Woche wenige Minuten zu investieren.
+
+## Warum manche Fragen oefter auftauchen
+
+Das Plugin folgt dem Leitner-Prinzip. Jede Frage gehoert intern zu einer Box. Niedrige Boxen stehen fuer Inhalte, die noch mehr Wiederholung brauchen. Hoehere Boxen zeigen an, dass ein Inhalt bereits stabiler sitzt. Wenn Sie eine Frage falsch beantworten, kann sie je nach Kurseinstellung zurueckgesetzt oder abgestuft werden. Das ist kein Nachteil, sondern Teil des Lernsystems.
+
+<div class="soft-panel">
+  <p><strong>Wichtig fuer die Motivation:</strong> Hauefige Wiederholung derselben Frage bedeutet nicht, dass etwas schieflaeuft. Sie zeigt vielmehr, worauf sich Ihre Aufmerksamkeit gerade konzentrieren sollte.</p>
+</div>
+
+## So nutzen Sie LeitnerFlow sinnvoll
+
+<div class="card-grid">
+  <div class="card">
+    <h3>Lieber regelmaessig als selten</h3>
+    <p>Mehrere kurze Sessions pro Woche bringen meist mehr als eine sehr lange Sitzung in grossen Abstaenden.</p>
+  </div>
+  <div class="card">
+    <h3>Rueckschritte einplanen</h3>
+    <p>Wenn Karten wieder nach unten rutschen, ist das kein Misserfolg, sondern ein Hinweis auf noch nicht gefestigtes Wissen.</p>
+  </div>
+  <div class="card">
+    <h3>Fortschritt lesen lernen</h3>
+    <p>Die Boxenverteilung und der Session-Verlauf helfen Ihnen einzuschaetzen, welche Inhalte bereits sicherer werden.</p>
+  </div>
+</div>
+
+## Was Sie auf dem Dashboard sehen
+
+Je nach Konfiguration sehen Sie eine Uebersicht ueber Boxen, Fortschritt und bisherige Sessions. Diese Anzeige ist als Lernhilfe gedacht. Sie macht sichtbar, wie sich Ihr Kartenpool entwickelt und ob sich regelmaessiges Ueben auszahlt.
+
+| Anzeige | Bedeutung |
+|---|---|
+| Boxenverteilung | Zeigt, wie viele Karten sich in welcher Wiederholungsstufe befinden |
+| Fortschrittsanzeige | Macht sichtbar, wie weit der Weg zu stabileren Karten bereits fortgeschritten ist |
+| Session-Verlauf | Hilft, Regelmaessigkeit und Entwicklung ueber mehrere Durchgaenge zu erkennen |
+
+## Gute Lerngewohnheiten mit LeitnerFlow
+
+<ul class="check-list">
+  <li>Planen Sie feste, kleine Lernfenster in Ihren Wochenablauf ein.</li>
+  <li>Arbeiten Sie konzentriert und ohne grosse Unterbrechungen durch eine Session.</li>
+  <li>Nutzen Sie Fehler als Hinweis auf Lernbedarf statt als Entmutigung.</li>
+  <li>Kombinieren Sie LeitnerFlow mit Notizen, Skript oder Lehrmaterial, wenn Inhalte erklaerungsbeduerftig sind.</li>
+  <li>Bleiben Sie ueber mehrere Wochen dran, damit die Wiederholungslogik ihren Effekt entfalten kann.</li>
+</ul>
+
+## Wann Sie Hilfe holen sollten
+
+Wenn keine Fragen erscheinen, die Aktivitaet nicht oeffnet oder der sichtbare Fortschritt nicht plausibel wirkt, wenden Sie sich an die zustaendige Lehrperson oder den Support Ihrer Moodle-Umgebung. Oft liegt die Ursache in der Konfiguration oder im zugrunde liegenden Fragenpool, nicht in Ihrem Bearbeitungsverhalten.
+
+## Noch mehr Orientierung
+
+Wenn Sie LeitnerFlow im Kurs besser verstehen moechten, hilft oft auch ein Blick in die [FAQ](faq.html). Lehrende finden weiterfuehrende Hinweise im [Guide fuer Lehrende](teacher-guide.html).

--- a/docs/teacher-guide.md
+++ b/docs/teacher-guide.md
@@ -1,20 +1,118 @@
-# LeitnerFlow für Lehrende
+---
+layout: page
+title: Guide fuer Lehrende
+description: LeitnerFlow didaktisch planen, konfigurieren und im Moodle-Kurs begleiten.
+---
 
-LeitnerFlow unterstützt nachhaltiges Lernen durch Wiederholung.
+<section class="page-hero">
+  <span class="eyebrow">Lehrende</span>
+  <h1>LeitnerFlow didaktisch in Moodle einsetzen</h1>
+  <p class="lead">LeitnerFlow ist besonders stark, wenn die Aktivitaet nicht als Zusatzspielerei, sondern als fester Bestandteil des Kursdesigns gedacht wird. Dieser Guide zeigt, wie aus vorhandenen Moodle-Fragen ein wiederholungsorientiertes Lernformat mit klarer Erwartungshaltung wird.</p>
+</section>
 
-## Aktivität erstellen
+## Wann sich LeitnerFlow besonders lohnt
 
-1. Kurs öffnen
-2. Aktivität hinzufügen
-3. LeitnerFlow auswählen
+LeitnerFlow eignet sich fuer Themen, bei denen Inhalte wiederholt abgerufen und ueber einen laengeren Zeitraum gesichert werden sollen. Das betrifft nicht nur klassisches Faktenwissen. Auch Begriffe, Definitionen, Regeln, Formeln, diagnostische Entscheidungsschritte oder standardisierte Verfahrenskenntnisse profitieren von einem Leitner-basierten Uebungsrhythmus.
 
-## Einstellungen
+<div class="card-grid">
+  <div class="card">
+    <h3>Pruefungsnahe Formate</h3>
+    <p>Die Aktivitaet begleitet Vorlesungen, Seminare oder Fortbildungen ueber Wochen hinweg und entlastet die Endphase vor einer Pruefung.</p>
+  </div>
+  <div class="card">
+    <h3>Kontinuierliche Selbstlernphasen</h3>
+    <p>LeitnerFlow passt gut zu Microlearning, Blended-Learning-Szenarien und regelmaessigen Uebungsimpulsen zwischen Praesenzterminen.</p>
+  </div>
+  <div class="card">
+    <h3>Wissenssicherung im Verlauf</h3>
+    <p>Gerade bei grossen Fragepools hilft das Plugin, Wiederholung strukturiert zu organisieren und sichtbaren Fortschritt zu erzeugen.</p>
+  </div>
+</div>
 
-- Fragenkategorien wählen
-- Fragen pro Sitzung festlegen
-- Boxen konfigurieren
+## Eine Aktivitaet sinnvoll planen
 
-## Tipps
+Bevor Sie die Aktivitaet anlegen, lohnt ein kurzer Blick auf das angestrebte Lernverhalten. LeitnerFlow belohnt Regelmaessigkeit. Deshalb ist es hilfreicher, kurze, wiederkehrende Sessions im Kurskonzept vorzusehen als einzelne sehr lange Uebungsphasen. Lernende sollten verstehen, dass das Ziel nicht die einmalige Maximalleistung ist, sondern die schrittweise Stabilisierung von Wissen.
 
-- kurze, regelmäßige Sitzungen
-- klare Fragen
+<div class="soft-panel">
+  <p><strong>Praxisempfehlung:</strong> Kommunizieren Sie LeitnerFlow als begleitendes Uebungsformat. Eine Formulierung wie "zwei bis drei kurze Sessions pro Woche" ist fuer Lernende meist klarer und wirksamer als eine offene Aufforderung zum freien Ueben.</p>
+</div>
+
+## Aktivitaet im Kurs anlegen
+
+1. Oeffnen Sie den gewuenschten Moodle-Kurs und aktivieren Sie den Bearbeitungsmodus.
+2. Fuegen Sie eine neue Aktivitaet hinzu und waehlen Sie `LeitnerFlow`.
+3. Vergeben Sie einen eindeutigen Namen, der den Zweck der Aktivitaet sichtbar macht.
+4. Waehlen Sie eine oder mehrere passende Fragenkategorien aus der Fragensammlung.
+5. Legen Sie Session-Groesse, Boxenzahl und Fehlerlogik passend zum Kursziel fest.
+6. Speichern Sie die Aktivitaet und pruefen Sie danach die Lernendenansicht kurz selbst.
+
+Schon beim Namen der Aktivitaet lohnt sich Praezision. Statt eines generischen Titels wie "LeitnerFlow 1" funktionieren sprechende Bezeichnungen besser, zum Beispiel "Klinische Begriffe wiederholen" oder "Einheiten und Formeln trainieren".
+
+## Gute Fragen fuer LeitnerFlow auswaehlen
+
+Nicht jede Frage ist fuer wiederholungsorientiertes Lernen gleich gut geeignet. Besonders hilfreich sind Fragen, die einen klaren Wissensabruf oder eine eindeutige Entscheidung foerdern. Je klarer der Gegenstand, desto besser versteht sich auch die Leitner-Logik fuer Lernende.
+
+| Geeignet | Weniger geeignet |
+|---|---|
+| Begriffe, Definitionen, Zuordnungen | sehr offene Reflexionsfragen |
+| Faktenwissen und Kernkonzepte | Aufgaben mit langem Antwortweg |
+| standardisierte Entscheidungssituationen | Einzelfragen mit grossem Interpretationsspielraum |
+| wiederkehrende Pruefungslogiken | Fragen, die primaer Diskussion anregen sollen |
+
+Wenn Sie verschiedene Fragetypen mischen, achten Sie auf ein ausgewogenes Anspruchsniveau. Eine Aktivitaet wirkt ruhiger und fairer, wenn der Fragepool in sich konsistent ist.
+
+## Sinnvolle Startkonfigurationen
+
+<div class="card-grid">
+  <div class="card">
+    <h3>Einfacher Einstieg</h3>
+    <p>3 Boxen, 10 bis 15 Fragen pro Session, Reset auf Box 1. Dieses Profil ist leicht erklaerbar und eignet sich fuer den ersten Einsatz fast immer.</p>
+  </div>
+  <div class="card">
+    <h3>Fortgeschrittene Nutzung</h3>
+    <p>4 bis 5 Boxen, groesserer Pool, differenzierte Auswahlstrategie. Sinnvoll, wenn Lernende das Prinzip bereits kennen und laengerfristig damit arbeiten.</p>
+  </div>
+  <div class="card">
+    <h3>Begleitendes Pruefungstraining</h3>
+    <p>Kurze Sessions mit klarer Taktung im Kurs. Besonders wirksam, wenn die Aktivitaet durch Erinnerungen oder feste Routinen begleitet wird.</p>
+  </div>
+</div>
+
+## Lernende gut einfuehren
+
+Die Qualitaet der Einfuehrung entscheidet stark ueber die Akzeptanz. Lernende sollten wissen, warum Karten unterschiedlich oft erscheinen und dass Rueckschritte kein Fehler des Systems, sondern Teil des Lernprinzips sind. Wer das versteht, interpretiert das Plugin eher als Unterstuetzung und weniger als Bewertung.
+
+Eine kurze Einfuehrung im Kursraum reicht oft aus. Erklaeren Sie, dass niedrigere Boxen mehr Aufmerksamkeit bekommen, dass sichere Karten seltener wiederkehren und dass Regelmaessigkeit wichtiger ist als einzelne Marathon-Sessions. Wenn LeitnerFlow benotet eingesetzt wird, sollten Sie die Bewertungslogik zusaetzlich transparent machen.
+
+## Lernfortschritt begleiten und Berichte nutzen
+
+LeitnerFlow liefert Lehrenden eine aussagekraeftige Sicht auf Aktivitaetsnutzung und Lernstand. Besonders aufschlussreich ist nicht nur der absolute Fortschrittswert, sondern die Kombination aus Session-Haeufigkeit, Boxenverteilung und Entwicklung im Zeitverlauf.
+
+<div class="info-grid">
+  <div class="card">
+    <h3>Wenig Sessions</h3>
+    <p>Deutet haeufig auf fehlende Routinen, unklare Kommunikation oder einen zu spaeten Einstieg im Kurs hin.</p>
+  </div>
+  <div class="card">
+    <h3>Viele Karten in unteren Boxen</h3>
+    <p>Kann auf anspruchsvolle Inhalte, einen unruhigen Fragenpool oder eine zu harte Fehlerlogik hindeuten.</p>
+  </div>
+  <div class="card">
+    <h3>Stetiger Anstieg gelernter Karten</h3>
+    <p>Ist ein gutes Signal dafuer, dass Wiederholung, Fragequalitaet und Session-Laenge zusammenpassen.</p>
+  </div>
+</div>
+
+## Gute Praxis fuer den Alltag
+
+<ul class="check-list">
+  <li>Verankern Sie LeitnerFlow sichtbar im Kursablauf und nicht nur im Materialbereich.</li>
+  <li>Empfehlen Sie kurze, regelmaessige Sessions statt gelegentlicher Langdurchgaenge.</li>
+  <li>Starten Sie mit wenigen, gut kuratierten Kategorien statt mit einem uebergrossen Pool.</li>
+  <li>Pruefen Sie die Aktivitaet nach dem ersten Einsatz aus Sicht der Lernenden.</li>
+  <li>Nutzen Sie Berichte, um Interventionen datenbasiert und nicht nur nach Bauchgefuehl zu planen.</li>
+</ul>
+
+## Wenn Sie weiterfuehren moechten
+
+Wenn die didaktische Rolle der Aktivitaet klar ist, lohnt als naechster Schritt der Blick in die [Konfiguration](configuration.html) fuer konkrete Einstellungen und in den [Guide fuer Lernende](student-guide.html), um Einfuehrungen und Hilfetexte aufeinander abzustimmen.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,75 @@
+---
+layout: page
+title: Troubleshooting
+description: Typische Probleme mit LeitnerFlow strukturiert analysieren.
+---
+
+<section class="page-hero">
+  <span class="eyebrow">Troubleshooting</span>
+  <h1>Typische Probleme schnell und systematisch eingrenzen</h1>
+  <p class="lead">LeitnerFlow laesst sich in Moodle in der Regel stabil betreiben. Wenn dennoch Probleme auftreten, liegen die Ursachen haeufig in Sichtbarkeit, Rechten, Fragenkategorien oder unklaren Erwartungen an die Aktivitaet. Diese Seite bietet eine pragmatische Pruefreihenfolge.</p>
+</section>
+
+## Die haeufigsten Fehlerbilder
+
+| Beobachtung | Typische Ursache | Erste sinnvolle Pruefung |
+|---|---|---|
+| Aktivitaet ist nicht auswaehlbar | Plugin nicht sauber installiert oder nicht aktualisiert | Installation, Upgrade und Plugin-Sichtbarkeit pruefen |
+| Keine Fragen erscheinen | leere oder unpassende Kategorien, Konfigurationsproblem | Fragenkategorien und Pool-Inhalt kontrollieren |
+| Lernende sehen die Aktivitaet nicht | Sichtbarkeit oder Rechte fehlen | Kursabschnitt, Verfuegbarkeit und Rollen pruefen |
+| Fortschritt wirkt unplausibel | Fehlerlogik oder Boxenprinzip missverstanden | Konfiguration und didaktische Einfuehrung abgleichen |
+| Berichtsdaten fehlen oder wirken leer | keine Sessions abgeschlossen oder Rechte fehlen | Testsession durchspielen und Rollen kontrollieren |
+
+## Schrittfolge fuer die Diagnose
+
+### 1. Installation und Plugin-Stand pruefen
+
+Wenn die Aktivitaet bereits nicht in der Modulliste erscheint, beginnen Sie mit dem Grundsystem. Pruefen Sie Installationspfad, Moodle-Mitteilungen und den aktuellen Plugin-Stand. Gerade nach Updates lohnt ein Blick darauf, ob das Upgrade vollstaendig durchgelaufen ist.
+
+### 2. Aktivitaetskonfiguration kontrollieren
+
+Wenn die Aktivitaet angelegt werden kann, aber im Kurs nicht sinnvoll arbeitet, ist die Konfiguration der naechste Blickpunkt. Pruefen Sie insbesondere, ob geeignete Fragenkategorien ausgewaehlt wurden und ob die Session-Konfiguration zum vorhandenen Fragenpool passt.
+
+### 3. Fragenpool gegenpruefen
+
+LeitnerFlow ist nur so stark wie der zugrunde liegende Fragenpool. Wenn Kategorien leer, unvollstaendig oder sehr heterogen sind, entstehen schnell scheinbar technische Fehler, die in Wahrheit inhaltliche Ursachen haben. Testen Sie im Zweifel mit einer kleinen, bewusst kuratierten Kategorie.
+
+### 4. Rollen und Sichtbarkeit pruefen
+
+Wenn Lehrende alles sehen, Lernende aber nicht, liegt die Ursache oft in Kursrechten, Abschnittssichtbarkeit oder Aktivitaetsverfuegbarkeit. Pruefen Sie die Aktivitaet einmal gezielt aus der Rolle einer lernenden Person.
+
+### 5. End-to-End-Test durchspielen
+
+Viele Probleme lassen sich am schnellsten erkennen, wenn eine komplette Testsession mit realen Fragen durchlaufen wird. So wird sichtbar, ob Ansicht, Frageausspielung, Session-Abschluss und Berichtsdaten konsistent zusammenspielen.
+
+## Spezifische Hinweise zu einzelnen Symptomen
+
+<div class="card-grid">
+  <div class="card">
+    <h3>Keine Fragen trotz vorhandener Aktivitaet</h3>
+    <p>Oft ist keine geeignete Kategorie zugewiesen oder der ausgewaehlte Pool enthaelt nicht die erwarteten Fragen. Beginnen Sie mit einer kleinen Testkategorie.</p>
+  </div>
+  <div class="card">
+    <h3>Fortschritt sinkt nach Fehlern</h3>
+    <p>Das kann je nach Konfiguration korrekt sein. Pruefen Sie, ob bei falscher Antwort ein Reset oder eine Rueckstufung vorgesehen ist.</p>
+  </div>
+  <div class="card">
+    <h3>Lernende sind irritiert vom Verhalten</h3>
+    <p>Dann fehlt oft keine Technik, sondern eine klare Einfuehrung. Erklaeren Sie das Leitner-Prinzip und die Rolle der Boxen noch einmal knapp im Kurs.</p>
+  </div>
+</div>
+
+## Support-Checkliste fuer den Betrieb
+
+<ul class="check-list">
+  <li>Plugin-Version und Moodle-Version abgleichen.</li>
+  <li>Installationspfad und erfolgreiches Upgrade bestaetigen.</li>
+  <li>Aktivitaet mit realer Fragenkategorie testen.</li>
+  <li>Rollen und Sichtbarkeit aus Lernendenperspektive pruefen.</li>
+  <li>Mindestens eine Session bis zum Ende durchspielen.</li>
+  <li>Berichtsansicht und Fortschrittsdarstellung danach kontrollieren.</li>
+</ul>
+
+## Wann eine Eskalation sinnvoll ist
+
+Wenn Installation, Rechte, Sichtbarkeit und Fragenpool nachweislich stimmen und das Verhalten trotzdem reproduzierbar fehlerhaft bleibt, ist eine tiefergehende Analyse des Plugins sinnvoll. Fuer eine saubere Eskalation sollten dann Moodle-Version, Plugin-Stand, konkrete Aktivitaetskonfiguration und das beobachtete Verhalten moeglichst klar dokumentiert sein.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,15 +1,16 @@
-# Benutzung
+---
+layout: page
+title: Nutzung
+description: Verweis auf die aktuelle Nutzungsdokumentation.
+nav_exclude: true
+---
 
-## Für Lernende
+# Nutzung
 
-Sitzung starten über die Aktivität und Fragen beantworten.
+Die Nutzungshinweise sind jetzt nach Zielgruppen getrennt dokumentiert, damit Einfuehrung und Alltagssupport klarer werden:
 
-Karten bewegen sich je nach Antwort zwischen den Boxen.
+- [Guide fuer Lehrende](teacher-guide.html) fuer Kursdesign, Konfiguration und Begleitung
+- [Guide fuer Lernende](student-guide.html) fuer Sessions, Fortschritt und Lernrhythmus
+- [FAQ](faq.html) fuer schnelle Antworten auf wiederkehrende Fragen
 
-## Für Lehrende
-
-Einstellungen konfigurieren und Fortschritt auswerten.
-
-## Tipps
-
-Regelmäßige kurze Sitzungen verbessern den Lernerfolg.
+So bleibt die oeffentliche Dokumentation konsistent, ohne bestehende Direktlinks unnoetig zu brechen.


### PR DESCRIPTION
## Summary
- rebuild the GitHub Pages landing page as a product-style entry point
- add consistent teacher, admin, student, configuration, troubleshooting, and FAQ pages
- refresh the Jekyll/Minima styling and docs configuration for a branded eLeDia look

## Testing
- git diff --check
- link and ASCII sanity checks over `docs/`
- local `jekyll build` not run because `jekyll` is not installed in this environment
